### PR TITLE
Add package.json to make package easy to install with mip in micropython

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+    "urls": [
+        ["udataclasses/__init__.py", "src/udataclasses/__init__.py"],
+        ["udataclasses/constants.py", "src/udataclasses/constants.py"],
+        ["udataclasses/decorator.py", "src/udataclasses/decorator.py"],
+        ["udataclasses/field.py", "src/udataclasses/field.py"],
+        ["udataclasses/functions.py", "src/udataclasses/functions.py"],
+        ["udataclasses/source.py", "src/udataclasses/source.py"],
+        ["udataclasses/transform_spec.py", "src/udataclasses/transform_spec.py"]
+    ]
+}


### PR DESCRIPTION
This adds a package.json file so that installing under micropython can be done just by running:
`micropython -m mip install github:dhrosa/udataclasses`