### PR TITLE
Make package.json compatible with micropython 1.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "urls": [
-        ["udataclasses/__init__.py", "src/udataclasses/__init__.py"],
-        ["udataclasses/constants.py", "src/udataclasses/constants.py"],
-        ["udataclasses/decorator.py", "src/udataclasses/decorator.py"],
-        ["udataclasses/field.py", "src/udataclasses/field.py"],
-        ["udataclasses/functions.py", "src/udataclasses/functions.py"],
-        ["udataclasses/source.py", "src/udataclasses/source.py"],
-        ["udataclasses/transform_spec.py", "src/udataclasses/transform_spec.py"]
+        ["udataclasses/__init__.py", "github:dhrosa/udataclasses/src/udataclasses/__init__.py"],
+        ["udataclasses/constants.py", "github:dhrosa/udataclasses/src/udataclasses/constants.py"],
+        ["udataclasses/decorator.py", "github:dhrosa/udataclasses/src/udataclasses/decorator.py"],
+        ["udataclasses/field.py", "github:dhrosa/udataclasses/src/udataclasses/field.py"],
+        ["udataclasses/functions.py", "github:dhrosa/udataclasses/src/udataclasses/functions.py"],
+        ["udataclasses/source.py", "github:dhrosa/udataclasses/src/udataclasses/source.py"],
+        ["udataclasses/transform_spec.py", "github:dhrosa/udataclasses/src/udataclasses/transform_spec.py"]
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+    "urls": [
+        ["udataclasses/__init__.py", "src/udataclasses/__init__.py"],
+        ["udataclasses/constants.py", "src/udataclasses/constants.py"],
+        ["udataclasses/decorator.py", "src/udataclasses/decorator.py"],
+        ["udataclasses/field.py", "src/udataclasses/field.py"],
+        ["udataclasses/functions.py", "src/udataclasses/functions.py"],
+        ["udataclasses/source.py", "src/udataclasses/source.py"],
+        ["udataclasses/transform_spec.py", "src/udataclasses/transform_spec.py"]
+    ]
+}


### PR DESCRIPTION
Looks like my initial version of package.json was compatible with the current version (from git) of micropython, but not with earlier versions - in particular not with micropthon 1.24.1 which is the version that PyScript uses, and which is my target use-case. This version seems to work correctly with micropython 1.24.1.